### PR TITLE
target for plugin should be the same as the capacitor target

### DIFF
--- a/CapacitorFingerprintAuth.podspec
+++ b/CapacitorFingerprintAuth.podspec
@@ -8,6 +8,6 @@
     s.author = 'Osei Fortune'
     s.source = { :git => '', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/Plugin/*.{swift,h,m,c,cc,mm,cpp}' ,'ios/Plugin/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}','ios/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '10.0'
+    s.ios.deployment_target  = '11.0'
     s.dependency 'Capacitor'
   end


### PR DESCRIPTION
When I installed this plugin in my project, I needed to update the deployment target in the plugin to match the capacitor deployment target (11.0) before I could get my project to run again.